### PR TITLE
revert recent dependency updates

### DIFF
--- a/jersey-json/pom.xml
+++ b/jersey-json/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    fanningpj elects to include this software in this distribution under the CDDL license."
+    fanningpj elects to include this software in this distribution under the CDDL license.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,9 +55,8 @@
 
     <properties>
         <jersey.core.version>1.19.4</jersey.core.version>
-        <jackson2.version>2.14.3</jackson2.version>
-        <jackson2.databind.version>2.14.3</jackson2.databind.version>
-        <jsr311-compat.version>0.1.0</jsr311-compat.version>
+        <jackson2.version>2.12.7</jackson2.version>
+        <jackson2.databind.version>2.12.7.1</jackson2.databind.version>
         <jaxb.version>2.2.3-1</jaxb.version>
         <moxy.version>2.4.2</moxy.version>
         <junit.version>4.13.2</junit.version>
@@ -171,12 +170,6 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson2.version}</version>
-        </dependency>
-        <!-- jsr311-compat is needed by jackson-jaxrs-json-provider (when jackson2.version >= 2.13.0) -->
-        <dependency>
-            <groupId>com.github.pjfanning</groupId>
-            <artifactId>jsr311-compat</artifactId>
-            <version>${jsr311-compat.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
v1.21.0 release does not work properly with Hadoop. The idea is to release a v1.22.0 that undoes the main changes so that the top release works with Hadoop.